### PR TITLE
fix: keep site/ directory for GitHub Pages deployment

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,5 @@
 github: FortuneN
 liberapay: FortuneN
 ko_fi: FortuneN
-custom: ['https://paypal.me/FortuneNgwenya', 'https://www.buymeacoffee.com/FortuneN']
+buy_me_a_coffee: FortuneN
+custom: ['https://paypal.me/FortuneNgwenya']

--- a/run-on-release-push.ps1
+++ b/run-on-release-push.ps1
@@ -269,10 +269,10 @@ if (-not (Test-PreviousStepsPassed)) {
 # Step 4: Deploy Documentation Site
 # =============================================================================
 
-Write-StepHeader 4 "Deploy Documentation Site"
+Write-StepHeader 4 "Build Documentation Site"
 
 if (-not (Test-PreviousStepsPassed)) {
-    Write-TaskSkipped "Documentation deployment" "previous step failed"
+    Write-TaskSkipped "Documentation build" "previous step failed"
     $script:Results["4. Deploy Docs"] = $false
 } else {
     $stepStart = Get-Date
@@ -282,17 +282,14 @@ if (-not (Test-PreviousStepsPassed)) {
     $buildSuccess = $LASTEXITCODE -eq 0
 
     if ($buildSuccess) {
-        Write-Task "Deploying to GitHub Pages..."
-        python -m mkdocs gh-deploy --force 2>&1 | Out-Null
-        $deploySuccess = $LASTEXITCODE -eq 0
-        Write-TaskResult "Documentation deployed to GitHub Pages" $deploySuccess
-        $script:Results["4. Deploy Docs"] = $deploySuccess
+        Write-TaskResult "Documentation site built successfully" $true
+        $script:Results["4. Deploy Docs"] = $true
     } else {
         Write-TaskResult "Documentation build failed" $false
         $script:Results["4. Deploy Docs"] = $false
     }
 
-    if (Test-Path "site") { Remove-Item -Recurse -Force "site" }
+    # Note: site/ directory is kept for GitHub Actions to upload to Pages
 
     $duration = Format-Duration((Get-Date) - $stepStart)
     Write-Host ""


### PR DESCRIPTION
The release workflow uses GitHub Actions to deploy Pages via upload-pages-artifact, but the PowerShell script was:
1. Running mkdocs gh-deploy (old method - pushes to gh-pages branch)
2. Deleting the site/ directory

This caused the workflow to fail because site/ didn't exist when upload-pages-artifact ran.

Changes:
- Remove mkdocs gh-deploy from the script (let GitHub Actions handle deployment)
- Keep site/ directory for the workflow to upload
- Rename step from 'Deploy Documentation Site' to 'Build Documentation Site'