### PR TITLE
fix: self-heal NATS destinations after terminal connection close

### DIFF
--- a/src/main/java/io/github/fortunen/kete/destinations/nats/NatsDestination.java
+++ b/src/main/java/io/github/fortunen/kete/destinations/nats/NatsDestination.java
@@ -10,13 +10,17 @@ import io.github.fortunen.kete.EventMessage;
 import io.github.fortunen.kete.utils.TemplateUtils;
 import io.github.fortunen.kete.utils.ValidationUtils;
 import io.nats.client.Connection;
+import io.nats.client.ConnectionListener;
 import io.nats.client.Nats;
+import io.nats.client.Options;
 import io.nats.client.impl.Headers;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
 @Component(name = "nats")
 @NoArgsConstructor(force = true)
@@ -24,9 +28,12 @@ import lombok.SneakyThrows;
 public class NatsDestination extends Destination<NatsDestinationConfig> {
 
 	private String subject;
-	private Connection connection;
+	private volatile Connection connection;
 	private boolean isSubjectTemplated;
 	private Set<Map.Entry<String, String>> customHeadersEntrySet;
+
+	private volatile boolean closed;
+	private final Object connectionLock = new Object();
 
 	@Override
 	@SneakyThrows
@@ -37,12 +44,8 @@ public class NatsDestination extends Destination<NatsDestinationConfig> {
 		subject = config.getSubject();
 		isSubjectTemplated = config.isSubjectTemplated();
 		customHeadersEntrySet = config.getCustomHeadersEntrySet();
-		
-		// verify connection
-		
-		connection = Nats.connect(config.getNatsOptions());
-		
-		ValidationUtils.requireTrue(connection.getStatus() == Connection.Status.CONNECTED, "failed to connect to NATS server");
+
+		reconnectIfNeeded();
 	}
 
 	@Override
@@ -67,13 +70,165 @@ public class NatsDestination extends Destination<NatsDestinationConfig> {
 		headers.put(Constants.MESSAGE_HEADER_EVENT_TYPE, message.eventType());
 		headers.put(Constants.MESSAGE_HEADER_CONTENT_TYPE, message.contentType());
 
+		// the client never recovers from a terminal CLOSED on its own; re-establish first
+
+		var currentConnection = connection;
+
+		if (currentConnection != null && currentConnection.getStatus() == Connection.Status.CLOSED) {
+			reconnectIfNeeded();
+		}
+
 		// publish
 
-		connection.publish(actualSubject, headers, message.eventBody());
+		try {
+			connection.publish(actualSubject, headers, message.eventBody());
+		} catch (IllegalStateException exception) {
+
+			// on a healthy connection the failure is not connection loss (e.g. a full
+			// output buffer) and a retry would fail the same way; propagate instead
+
+			var connectionAfterFailure = connection;
+
+			if (connectionAfterFailure != null && connectionAfterFailure.getStatus() == Connection.Status.CONNECTED) {
+				throw exception;
+			}
+
+			// the connection died underneath the publish; re-establish once and retry,
+			// otherwise let the failure propagate
+
+			reconnectIfNeeded();
+			connection.publish(actualSubject, headers, message.eventBody());
+		}
 	}
 
 	@Override
 	public void close() {
-		ValidationUtils.tryClose(connection, "connection");
+
+		Connection currentConnection;
+
+		synchronized (connectionLock) {
+			closed = true;
+			currentConnection = connection;
+		}
+
+		ValidationUtils.tryClose(currentConnection, "connection");
+	}
+
+	private Options buildOptions() {
+		return new Options.Builder(config.getNatsOptions())
+			.connectionListener(this::onConnectionEvent)
+			.build();
+	}
+
+	private void reconnectIfNeeded() {
+
+		synchronized (connectionLock) {
+
+			if (closed) {
+				throw new IllegalStateException("destination is closed");
+			}
+
+			var currentConnection = connection;
+
+			if (currentConnection != null && currentConnection.getStatus() == Connection.Status.CONNECTED) {
+				return;
+			}
+
+			connect();
+
+			ValidationUtils.tryClose(currentConnection, "connection");
+		}
+	}
+
+	@SneakyThrows
+	protected void connect() {
+
+		var newConnection = Nats.connect(buildOptions());
+
+		try {
+
+			// verify connection
+
+			ValidationUtils.requireTrue(newConnection.getStatus() == Connection.Status.CONNECTED, "failed to connect to NATS server");
+
+			connection = newConnection;
+
+		} catch (Exception exception) {
+
+			ValidationUtils.tryClose(newConnection, "connection");
+
+			if (connection == newConnection) {
+				connection = null;
+			}
+
+			throw exception;
+		}
+	}
+
+	private void onConnectionEvent(Connection eventConnection, ConnectionListener.Events event) {
+
+		switch (event) {
+			case DISCONNECTED -> log.warn("NATS connection lost, client is reconnecting");
+			case RECONNECTED -> log.warn("NATS connection re-established by client reconnect");
+			case CONNECTED -> adoptConnection(eventConnection);
+			case CLOSED -> onConnectionClosed(eventConnection);
+			default -> { /* not relevant */ }
+		}
+	}
+
+	private void onConnectionClosed(Connection eventConnection) {
+
+		synchronized (connectionLock) {
+
+			if (closed || eventConnection != connection) {
+				return;
+			}
+
+			// terminal state (e.g. repeated auth failures during reconnect); the client will
+			// not recover this connection on its own, so let it dial a new one in the
+			// background using its own reconnect policy; the new connection arrives via a
+			// CONNECTED event and is adopted there; the dial retries indefinitely (matching
+			// maxReconnects(-1)) because giving up would permanently stop publishing, and it
+			// logs one error per terminal close, not per attempt
+			log.error("NATS connection closed permanently, re-establishing in the background");
+
+			try {
+				Nats.connectAsynchronously(buildOptions(), true);
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+				log.error("Interrupted while starting NATS background reconnect");
+			}
+		}
+	}
+
+	private void adoptConnection(Connection newConnection) {
+
+		Connection redundantConnection;
+
+		synchronized (connectionLock) {
+
+			if (newConnection == connection) {
+				return; // synchronous connect; connect() adopts it itself
+			}
+
+			if (newConnection.getStatus() != Connection.Status.CONNECTED) {
+				return; // died before adoption (e.g. a failed synchronous connect closed it)
+			}
+
+			var currentConnection = connection;
+
+			if (closed || (currentConnection != null && currentConnection.getStatus() == Connection.Status.CONNECTED)) {
+				// destination closed, or a send already re-established the connection
+				redundantConnection = newConnection;
+			} else {
+				connection = newConnection;
+				redundantConnection = currentConnection;
+				log.warn("NATS connection re-established after terminal close");
+			}
+		}
+
+		// close outside the lock; closing can block on the connection's callback threads
+
+		ValidationUtils.tryClose(redundantConnection, "connection");
 	}
 }

--- a/src/main/java/io/github/fortunen/kete/destinations/natsjetstream/NatsJetStreamDestination.java
+++ b/src/main/java/io/github/fortunen/kete/destinations/natsjetstream/NatsJetStreamDestination.java
@@ -1,5 +1,6 @@
 package io.github.fortunen.kete.destinations.natsjetstream;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
@@ -10,16 +11,20 @@ import io.github.fortunen.kete.EventMessage;
 import io.github.fortunen.kete.utils.TemplateUtils;
 import io.github.fortunen.kete.utils.ValidationUtils;
 import io.nats.client.Connection;
+import io.nats.client.ConnectionListener;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamOptions;
 import io.nats.client.Nats;
+import io.nats.client.Options;
 import io.nats.client.impl.Headers;
 import io.nats.client.impl.NatsMessage;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
 @NoArgsConstructor(force = true)
 @Component(name = "nats-jetstream")
@@ -27,10 +32,13 @@ import lombok.SneakyThrows;
 public class NatsJetStreamDestination extends Destination<NatsJetStreamDestinationConfig> {
 
 	private String subject;
-	private JetStream jetStream;
-	private Connection connection;
+	private volatile JetStream jetStream;
+	private volatile Connection connection;
 	private boolean isSubjectTemplated;
 	private Set<Map.Entry<String, String>> customHeadersEntrySet;
+
+	private volatile boolean closed;
+	private final Object connectionLock = new Object();
 
 	@Override
 	@SneakyThrows
@@ -42,28 +50,7 @@ public class NatsJetStreamDestination extends Destination<NatsJetStreamDestinati
 		isSubjectTemplated = config.isSubjectTemplated();
 		customHeadersEntrySet = config.getCustomHeadersEntrySet();
 
-		connection = Nats.connect(config.getNatsOptions());
-
-		// verify connection
-
-		ValidationUtils.requireTrue(connection.getStatus() == Connection.Status.CONNECTED, "failed to connect to NATS server");
-
-		// verify stream exists
-
-		var jsm = connection.jetStreamManagement();
-
-		if (jsm.getStreamInfo(config.getStream()) == null) {
-			throw new IllegalStateException("stream '" + config.getStream() + "' does not exist on the NATS server");
-		}
-
-		// jetStream
-
-		var jsOptions = JetStreamOptions.builder()
-			.publishNoAck(false)
-			.requestTimeout(config.getPublishTimeout())
-			.build();
-
-		jetStream = connection.jetStream(jsOptions);
+		reconnectIfNeeded();
 	}
 
 	@Override
@@ -96,13 +83,188 @@ public class NatsJetStreamDestination extends Destination<NatsJetStreamDestinati
 
 		messageBuilder.headers(headers);
 
+		var natsMessage = messageBuilder.build();
+
+		// the client never recovers from a terminal CLOSED on its own; re-establish first
+
+		var currentConnection = connection;
+
+		if (currentConnection != null && currentConnection.getStatus() == Connection.Status.CLOSED) {
+			reconnectIfNeeded();
+		}
+
 		// publish with ack (blocks until server acknowledges or timeout)
 
-		jetStream.publish(messageBuilder.build());
+		try {
+			jetStream.publish(natsMessage);
+		} catch (IOException | IllegalStateException exception) {
+
+			// on a healthy connection the failure is a bare ack timeout and the publish may
+			// have reached the stream; retrying could double-publish, so propagate instead
+
+			var connectionAfterFailure = connection;
+
+			if (connectionAfterFailure != null && connectionAfterFailure.getStatus() == Connection.Status.CONNECTED) {
+				throw exception;
+			}
+
+			// the connection died underneath the publish; re-establish once and retry,
+			// otherwise let the failure propagate
+
+			reconnectIfNeeded();
+			jetStream.publish(natsMessage);
+		}
 	}
 
 	@Override
 	public void close() {
-		ValidationUtils.tryClose(connection, "connection");
+
+		Connection currentConnection;
+
+		synchronized (connectionLock) {
+			closed = true;
+			currentConnection = connection;
+		}
+
+		ValidationUtils.tryClose(currentConnection, "connection");
+	}
+
+	private Options buildOptions() {
+		return new Options.Builder(config.getNatsOptions())
+			.connectionListener(this::onConnectionEvent)
+			.build();
+	}
+
+	private JetStreamOptions buildJetStreamOptions() {
+		return JetStreamOptions.builder()
+			.publishNoAck(false)
+			.requestTimeout(config.getPublishTimeout())
+			.build();
+	}
+
+	private void reconnectIfNeeded() {
+
+		synchronized (connectionLock) {
+
+			if (closed) {
+				throw new IllegalStateException("destination is closed");
+			}
+
+			var currentConnection = connection;
+
+			if (currentConnection != null && currentConnection.getStatus() == Connection.Status.CONNECTED) {
+				return;
+			}
+
+			connect();
+
+			ValidationUtils.tryClose(currentConnection, "connection");
+		}
+	}
+
+	@SneakyThrows
+	protected void connect() {
+
+		var newConnection = Nats.connect(buildOptions());
+
+		try {
+
+			// verify connection
+
+			ValidationUtils.requireTrue(newConnection.getStatus() == Connection.Status.CONNECTED, "failed to connect to NATS server");
+
+			// verify stream exists
+
+			var jsm = newConnection.jetStreamManagement();
+
+			if (jsm.getStreamInfo(config.getStream()) == null) {
+				throw new IllegalStateException("stream '" + config.getStream() + "' does not exist on the NATS server");
+			}
+
+			// jetStream
+
+			jetStream = newConnection.jetStream(buildJetStreamOptions());
+			connection = newConnection;
+
+		} catch (Exception exception) {
+
+			ValidationUtils.tryClose(newConnection, "connection");
+
+			if (connection == newConnection) {
+				connection = null;
+				jetStream = null;
+			}
+
+			throw exception;
+		}
+	}
+
+	private void onConnectionEvent(Connection eventConnection, ConnectionListener.Events event) {
+
+		switch (event) {
+			case DISCONNECTED -> log.warn("NATS connection lost, client is reconnecting");
+			case RECONNECTED -> log.warn("NATS connection re-established by client reconnect");
+			case CONNECTED -> adoptConnection(eventConnection);
+			case CLOSED -> onConnectionClosed(eventConnection);
+			default -> { /* not relevant */ }
+		}
+	}
+
+	private void onConnectionClosed(Connection eventConnection) {
+
+		synchronized (connectionLock) {
+
+			if (closed || eventConnection != connection) {
+				return;
+			}
+
+			// terminal state (e.g. repeated auth failures during reconnect); the client will
+			// not recover this connection on its own, so let it dial a new one in the
+			// background using its own reconnect policy; the new connection arrives via a
+			// CONNECTED event and is adopted there; the dial retries indefinitely (matching
+			// maxReconnects(-1)) because giving up would permanently stop publishing, and it
+			// logs one error per terminal close, not per attempt
+			log.error("NATS connection closed permanently, re-establishing in the background");
+
+			try {
+				Nats.connectAsynchronously(buildOptions(), true);
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+				log.error("Interrupted while starting NATS background reconnect");
+			}
+		}
+	}
+
+	@SneakyThrows
+	private void adoptConnection(Connection newConnection) {
+
+		Connection redundantConnection;
+
+		synchronized (connectionLock) {
+
+			if (newConnection == connection) {
+				return; // synchronous connect; connect() adopts it itself
+			}
+
+			if (newConnection.getStatus() != Connection.Status.CONNECTED) {
+				return; // died before adoption (e.g. a failed synchronous connect closed it)
+			}
+
+			var currentConnection = connection;
+
+			if (closed || (currentConnection != null && currentConnection.getStatus() == Connection.Status.CONNECTED)) {
+				// destination closed, or a send already re-established the connection
+				redundantConnection = newConnection;
+			} else {
+				jetStream = newConnection.jetStream(buildJetStreamOptions());
+				connection = newConnection;
+				redundantConnection = currentConnection;
+				log.warn("NATS JetStream connection re-established after terminal close");
+			}
+		}
+
+		// close outside the lock; closing can block on the connection's callback threads
+
+		ValidationUtils.tryClose(redundantConnection, "connection");
 	}
 }

--- a/src/test/java/io/github/fortunen/kete/integrationtests/natsdestination/reconnectTests.java
+++ b/src/test/java/io/github/fortunen/kete/integrationtests/natsdestination/reconnectTests.java
@@ -1,0 +1,108 @@
+package io.github.fortunen.kete.integrationtests.natsdestination;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+
+import org.apache.commons.configuration2.MapConfiguration;
+import org.junit.jupiter.api.Test;
+
+import io.github.fortunen.kete.EventMessage;
+import io.nats.client.Connection;
+
+public class reconnectTests extends TestBase {
+
+	private void arrangeDestination() throws Exception {
+
+		startNats();
+
+		var map = new HashMap<String, Object>();
+		map.put("servers", getNatsUrl());
+		map.put("subject", "test-subject");
+		map.put("authentication-method", "none");
+		var mapConfig = new MapConfiguration(map);
+		configureDestination(mapConfig);
+		destination.initialize();
+	}
+
+	private EventMessage createLoginMessage(String eventId) {
+		return createMessage(
+			eventId,
+			"test-realm",
+			false,
+			"LOGIN",
+			"application/json",
+			"{\"type\":\"LOGIN\"}".getBytes(StandardCharsets.UTF_8),
+			null,
+			null
+		);
+	}
+
+	@Test
+	public void shouldRecoverInBackgroundAfterTerminalConnectionClose() throws Exception {
+
+		// arrange
+
+		arrangeDestination();
+
+		var collector = new MessageCollector();
+		try (var subscriber = createSubscriber("test-subject", collector)) {
+
+			Thread.sleep(500);
+
+			destination.send(createLoginMessage("evt-001"));
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 1);
+
+			// act
+
+			var staleConnection = destination.getConnection();
+			staleConnection.close();
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() ->
+				destination.getConnection() != staleConnection
+					&& destination.getConnection().getStatus() == Connection.Status.CONNECTED);
+
+			destination.send(createLoginMessage("evt-002"));
+
+			// assert
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 2);
+
+			assertThat(collector.getMessages()).hasSize(2);
+		}
+	}
+
+	@Test
+	public void shouldRecoverOnSendAfterTerminalConnectionClose() throws Exception {
+
+		// arrange
+
+		arrangeDestination();
+
+		var collector = new MessageCollector();
+		try (var subscriber = createSubscriber("test-subject", collector)) {
+
+			Thread.sleep(500);
+
+			destination.send(createLoginMessage("evt-001"));
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 1);
+
+			// act
+
+			destination.getConnection().close();
+
+			destination.send(createLoginMessage("evt-002"));
+
+			// assert
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 2);
+
+			assertThat(collector.getMessages()).hasSize(2);
+		}
+	}
+}

--- a/src/test/java/io/github/fortunen/kete/integrationtests/natsjetstreamdestination/reconnectTests.java
+++ b/src/test/java/io/github/fortunen/kete/integrationtests/natsjetstreamdestination/reconnectTests.java
@@ -1,0 +1,174 @@
+package io.github.fortunen.kete.integrationtests.natsjetstreamdestination;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import org.apache.commons.configuration2.MapConfiguration;
+import org.junit.jupiter.api.Test;
+
+import io.github.fortunen.kete.EventMessage;
+import io.nats.client.Connection;
+
+public class reconnectTests extends TestBase {
+
+	private void arrangeDestination() throws Exception {
+
+		startNatsJetStream();
+
+		var map = new HashMap<String, Object>();
+		map.put("servers", getNatsUrl());
+		map.put("subject", "test.subject");
+		map.put("stream", STREAM_NAME);
+		map.put("authentication-method", "none");
+		var mapConfig = new MapConfiguration(map);
+		configureDestination(mapConfig);
+		destination.initialize();
+	}
+
+	private EventMessage createLoginMessage(String eventId) {
+		return createMessage(
+			eventId,
+			"test-realm",
+			false,
+			"LOGIN",
+			"application/json",
+			"{\"type\":\"LOGIN\"}".getBytes(StandardCharsets.UTF_8),
+			null,
+			null
+		);
+	}
+
+	@Test
+	public void shouldRecoverInBackgroundAfterTerminalConnectionClose() throws Exception {
+
+		// arrange
+
+		arrangeDestination();
+
+		var collector = new MessageCollector();
+		try (var subscriber = createSubscriber("test.subject", collector)) {
+
+			Thread.sleep(500);
+
+			destination.send(createLoginMessage("evt-001"));
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 1);
+
+			// act
+
+			var staleConnection = destination.getConnection();
+			staleConnection.close();
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() ->
+				destination.getConnection() != staleConnection
+					&& destination.getConnection().getStatus() == Connection.Status.CONNECTED);
+
+			destination.send(createLoginMessage("evt-002"));
+
+			// assert
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 2);
+
+			assertThat(collector.getMessages()).hasSize(2);
+		}
+	}
+
+	@Test
+	public void shouldRecoverOnSendAfterTerminalConnectionClose() throws Exception {
+
+		// arrange
+
+		arrangeDestination();
+
+		var collector = new MessageCollector();
+		try (var subscriber = createSubscriber("test.subject", collector)) {
+
+			Thread.sleep(500);
+
+			destination.send(createLoginMessage("evt-001"));
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 1);
+
+			// act
+
+			destination.getConnection().close();
+
+			destination.send(createLoginMessage("evt-002"));
+
+			// assert
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == 2);
+
+			assertThat(collector.getMessages()).hasSize(2);
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> getServerConnectionCount() == 2);
+		}
+	}
+
+	private int getServerConnectionCount() throws Exception {
+
+		var url = "http://127.0.0.1:" + container.getMappedPort(NATS_MONITORING_PORT) + "/connz";
+
+		try (var stream = URI.create(url).toURL().openStream()) {
+
+			var body = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+			var matcher = Pattern.compile("\"num_connections\"\\s*:\\s*(\\d+)").matcher(body);
+
+			if (!matcher.find()) {
+				throw new IllegalStateException("num_connections not found in " + url + " response");
+			}
+
+			return Integer.parseInt(matcher.group(1));
+		}
+	}
+
+	@Test
+	public void shouldRecoverOnConcurrentSendsAfterTerminalConnectionClose() throws Exception {
+
+		// arrange
+
+		var sendCount = 8;
+
+		arrangeDestination();
+
+		var collector = new MessageCollector();
+		try (var subscriber = createSubscriber("test.subject", collector)) {
+
+			Thread.sleep(500);
+
+			// act
+
+			destination.getConnection().close();
+
+			try (var executor = Executors.newFixedThreadPool(sendCount)) {
+
+				var futures = new ArrayList<Future<?>>();
+
+				for (var i = 0; i < sendCount; i++) {
+					var eventId = "evt-" + i;
+					futures.add(executor.submit(() -> destination.send(createLoginMessage(eventId))));
+				}
+
+				for (var future : futures) {
+					future.get();
+				}
+			}
+
+			// assert
+
+			await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).until(() -> collector.getMessages().size() == sendCount);
+
+			assertThat(collector.getMessages()).hasSize(sendCount);
+			assertThat(destination.getConnection().getStatus()).isEqualTo(Connection.Status.CONNECTED);
+		}
+	}
+}

--- a/src/test/java/io/github/fortunen/kete/unittests/destinations/natsdestination/sendTests.java
+++ b/src/test/java/io/github/fortunen/kete/unittests/destinations/natsdestination/sendTests.java
@@ -3,13 +3,23 @@ package io.github.fortunen.kete.unittests.destinations.natsdestination;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -116,5 +126,128 @@ public class sendTests {
 
 		assertThat(thrown).isInstanceOf(IllegalStateException.class);
 		assertThat(thrown.getMessage()).isEqualTo("message is required");
+	}
+
+	@Test
+	public void shouldNotRetryPublishWhenConnectionIsHealthy() {
+
+		// arrange
+
+		var connection = mock(Connection.class);
+		when(connection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+		doThrow(new IllegalStateException("Output queue is full")).when(connection).publish(anyString(), any(Headers.class), any(byte[].class));
+
+		destination.setConnection(connection);
+		destination.setSubject("test-subject");
+		destination.setSubjectTemplated(false);
+		destination.setCustomHeadersEntrySet(Set.of());
+
+		var body = "test-body".getBytes(StandardCharsets.UTF_8);
+		var message = new EventMessage("test-realm", "evt-004", body, "LOGIN", "application/json", null, Constants.EVENT, null, null);
+
+		// act
+
+		var thrown = catchThrowable(() -> destination.doSend(message));
+
+		// assert
+
+		assertThat(thrown).isInstanceOf(IllegalStateException.class);
+		verify(connection, times(1)).publish(anyString(), any(Headers.class), any(byte[].class));
+	}
+
+	@Test
+	public void shouldReconnectAndRetryPublishOnceWhenConnectionClosed() {
+
+		// arrange
+
+		var connectCount = new AtomicInteger();
+		var staleConnection = mock(Connection.class);
+		var freshConnection = mock(Connection.class);
+
+		when(staleConnection.getStatus()).thenReturn(Connection.Status.CONNECTED, Connection.Status.CLOSED);
+		when(freshConnection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+		doThrow(new IllegalStateException("Connection is Closed")).when(staleConnection).publish(anyString(), any(Headers.class), any(byte[].class));
+
+		var recoveringDestination = new NatsDestination() {
+			@Override
+			protected void connect() {
+				connectCount.incrementAndGet();
+				setConnection(freshConnection);
+			}
+		};
+
+		recoveringDestination.setConnection(staleConnection);
+		recoveringDestination.setSubject("test-subject");
+		recoveringDestination.setSubjectTemplated(false);
+		recoveringDestination.setCustomHeadersEntrySet(Set.of());
+
+		var body = "test-body".getBytes(StandardCharsets.UTF_8);
+		var message = new EventMessage("test-realm", "evt-005", body, "LOGIN", "application/json", null, Constants.EVENT, null, null);
+
+		// act
+
+		recoveringDestination.doSend(message);
+
+		// assert
+
+		assertThat(connectCount.get()).isEqualTo(1);
+		verify(staleConnection, times(1)).publish(anyString(), any(Headers.class), any(byte[].class));
+		verify(freshConnection, times(1)).publish(anyString(), any(Headers.class), any(byte[].class));
+	}
+
+	@Test
+	public void shouldReconnectOnlyOnceForConcurrentSendsAfterTerminalClose() throws Exception {
+
+		// arrange
+
+		var sendCount = 8;
+		var connectCount = new AtomicInteger();
+		var staleConnection = mock(Connection.class);
+		var freshConnection = mock(Connection.class);
+
+		when(staleConnection.getStatus()).thenReturn(Connection.Status.CLOSED);
+		when(freshConnection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+
+		var recoveringDestination = new NatsDestination() {
+			@Override
+			protected void connect() {
+				try {
+					Thread.sleep(100);
+				} catch (InterruptedException exception) {
+					Thread.currentThread().interrupt();
+				}
+				connectCount.incrementAndGet();
+				setConnection(freshConnection);
+			}
+		};
+
+		recoveringDestination.setConnection(staleConnection);
+		recoveringDestination.setSubject("test-subject");
+		recoveringDestination.setSubjectTemplated(false);
+		recoveringDestination.setCustomHeadersEntrySet(Set.of());
+
+		var body = "test-body".getBytes(StandardCharsets.UTF_8);
+
+		// act
+
+		try (var executor = Executors.newFixedThreadPool(sendCount)) {
+
+			var futures = new ArrayList<Future<?>>();
+
+			for (var i = 0; i < sendCount; i++) {
+				var message = new EventMessage("test-realm", "evt-" + i, body, "LOGIN", "application/json", null, Constants.EVENT, null, null);
+				futures.add(executor.submit(() -> recoveringDestination.doSend(message)));
+			}
+
+			for (var future : futures) {
+				future.get(30, TimeUnit.SECONDS);
+			}
+		}
+
+		// assert
+
+		assertThat(connectCount.get()).isEqualTo(1);
+		verify(staleConnection, never()).publish(anyString(), any(Headers.class), any(byte[].class));
+		verify(freshConnection, times(sendCount)).publish(anyString(), any(Headers.class), any(byte[].class));
 	}
 }

--- a/src/test/java/io/github/fortunen/kete/unittests/destinations/natsjetstreamdestination/sendTests.java
+++ b/src/test/java/io/github/fortunen/kete/unittests/destinations/natsjetstreamdestination/sendTests.java
@@ -4,10 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -17,6 +26,7 @@ import io.github.fortunen.kete.Constants;
 import io.github.fortunen.kete.EventMessage;
 import io.github.fortunen.kete.destinations.natsjetstream.NatsJetStreamDestination;
 import io.github.fortunen.kete.utils.ValidationUtils;
+import io.nats.client.Connection;
 import io.nats.client.JetStream;
 import io.nats.client.impl.NatsMessage;
 
@@ -91,5 +101,138 @@ public class sendTests {
 
 		assertThat(thrown).isInstanceOf(IllegalStateException.class);
 		assertThat(thrown.getMessage()).isEqualTo("message is required");
+	}
+
+	@Test
+	public void shouldNotRetryPublishWhenConnectionIsHealthy() throws Exception {
+
+		// arrange
+
+		var jetStream = mock(JetStream.class);
+		var connection = mock(Connection.class);
+		when(connection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+		when(jetStream.publish(any(NatsMessage.class))).thenThrow(new IOException("Timeout or no response waiting for NATS JetStream server"));
+
+		destination.setJetStream(jetStream);
+		destination.setConnection(connection);
+		destination.setSubject("test-subject");
+		destination.setSubjectTemplated(false);
+		destination.setCustomHeadersEntrySet(Set.of());
+
+		var body = "test-body".getBytes(StandardCharsets.UTF_8);
+		var message = new EventMessage("test-realm", "evt-004", body, "LOGIN", "application/json", null, Constants.EVENT, null, null);
+
+		// act
+
+		var thrown = catchThrowable(() -> destination.doSend(message));
+
+		// assert
+
+		assertThat(thrown).isInstanceOf(IOException.class);
+		verify(jetStream, times(1)).publish(any(NatsMessage.class));
+	}
+
+	@Test
+	public void shouldReconnectAndRetryPublishOnceWhenConnectionClosed() throws Exception {
+
+		// arrange
+
+		var connectCount = new AtomicInteger();
+		var staleJetStream = mock(JetStream.class);
+		var staleConnection = mock(Connection.class);
+		var freshJetStream = mock(JetStream.class);
+		var freshConnection = mock(Connection.class);
+
+		when(staleConnection.getStatus()).thenReturn(Connection.Status.CONNECTED, Connection.Status.CLOSED);
+		when(freshConnection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+		when(staleJetStream.publish(any(NatsMessage.class))).thenThrow(new IllegalStateException("Connection is Closed"));
+
+		var recoveringDestination = new NatsJetStreamDestination() {
+			@Override
+			protected void connect() {
+				connectCount.incrementAndGet();
+				setJetStream(freshJetStream);
+				setConnection(freshConnection);
+			}
+		};
+
+		recoveringDestination.setJetStream(staleJetStream);
+		recoveringDestination.setConnection(staleConnection);
+		recoveringDestination.setSubject("test-subject");
+		recoveringDestination.setSubjectTemplated(false);
+		recoveringDestination.setCustomHeadersEntrySet(Set.of());
+
+		var body = "test-body".getBytes(StandardCharsets.UTF_8);
+		var message = new EventMessage("test-realm", "evt-005", body, "LOGIN", "application/json", null, Constants.EVENT, null, null);
+
+		// act
+
+		recoveringDestination.doSend(message);
+
+		// assert
+
+		assertThat(connectCount.get()).isEqualTo(1);
+		verify(staleJetStream, times(1)).publish(any(NatsMessage.class));
+		verify(freshJetStream, times(1)).publish(any(NatsMessage.class));
+	}
+
+	@Test
+	public void shouldReconnectOnlyOnceForConcurrentSendsAfterTerminalClose() throws Exception {
+
+		// arrange
+
+		var sendCount = 8;
+		var connectCount = new AtomicInteger();
+		var staleJetStream = mock(JetStream.class);
+		var staleConnection = mock(Connection.class);
+		var freshJetStream = mock(JetStream.class);
+		var freshConnection = mock(Connection.class);
+
+		when(staleConnection.getStatus()).thenReturn(Connection.Status.CLOSED);
+		when(freshConnection.getStatus()).thenReturn(Connection.Status.CONNECTED);
+
+		var recoveringDestination = new NatsJetStreamDestination() {
+			@Override
+			protected void connect() {
+				try {
+					Thread.sleep(100);
+				} catch (InterruptedException exception) {
+					Thread.currentThread().interrupt();
+				}
+				connectCount.incrementAndGet();
+				setJetStream(freshJetStream);
+				setConnection(freshConnection);
+			}
+		};
+
+		recoveringDestination.setJetStream(staleJetStream);
+		recoveringDestination.setConnection(staleConnection);
+		recoveringDestination.setSubject("test-subject");
+		recoveringDestination.setSubjectTemplated(false);
+		recoveringDestination.setCustomHeadersEntrySet(Set.of());
+
+		var body = "test-body".getBytes(StandardCharsets.UTF_8);
+
+		// act
+
+		try (var executor = Executors.newFixedThreadPool(sendCount)) {
+
+			var futures = new ArrayList<Future<?>>();
+
+			for (var i = 0; i < sendCount; i++) {
+				var message = new EventMessage("test-realm", "evt-" + i, body, "LOGIN", "application/json", null, Constants.EVENT, null, null);
+				futures.add(executor.submit(() -> recoveringDestination.doSend(message)));
+			}
+
+			for (var future : futures) {
+				future.get(30, TimeUnit.SECONDS);
+			}
+		}
+
+		// assert
+
+		assertThat(connectCount.get()).isEqualTo(1);
+		verify(staleJetStream, never()).publish(any(NatsMessage.class));
+		verify(freshJetStream, times(sendCount)).publish(any(NatsMessage.class));
 	}
 }


### PR DESCRIPTION
Both NATS destinations created their Connection (and JetStream context) once in doInitialize and reused it forever. maxReconnects(-1) covers transient blips, but once the client reaches the terminal CLOSED state (e.g. repeated auth failures during reconnect) it never recovers, so publishing silently stopped until a pod restart.

- register a ConnectionListener on both NATS destinations
- on terminal CLOSED, re-dial via Nats.connectAsynchronously using the client's own reconnect policy; adopt the new connection (and JetStream context) on the CONNECTED event
- doSend re-establishes once and retries the publish only when the connection is actually broken; failures on a healthy connection (e.g. a bare ack timeout) propagate to avoid double-publishing
- guard connection state with a lock and volatile fields for concurrent sends
- add unit tests for the retry semantics and the concurrent single-re-init guard, and integration tests proving publishing resumes without re-initialization and without leaking connections