### PR TITLE
feat: add JSON Schema for Event and AdminEvent NATS messages

### DIFF
--- a/docs/user-guide/serializers/json.md
+++ b/docs/user-guide/serializers/json.md
@@ -54,3 +54,187 @@ kete.routes.<name>.serializer.kind=json
   "resourceTypeAsString": "USER"
 }
 ```
+
+## Schemas
+
+JSON Schema (draft 2020-12) files describing both message shapes are in the [`schemas/json/`](https://github.com/FortuneN/kete/tree/develop/schemas/json) directory. Use them to validate or generate types for messages on the consumer side (e.g. `ajv`, `jsonschema`, `json-schema-validator`). The `eventkind` message header (`x-eventkind` for HTTP and SOAP) tells you which schema applies: `EVENT` or `ADMIN_EVENT`.
+
+### Event
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/FortuneN/kete/develop/schemas/json/event.json",
+  "title": "Event",
+  "description": "Keycloak user event as produced by the KETE JSON serializer (message header eventkind = EVENT; x-eventkind for HTTP and SOAP)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["string", "null"],
+      "description": "Unique event identifier (UUID)"
+    },
+    "time": {
+      "type": "integer",
+      "description": "Event timestamp in milliseconds since Unix epoch (0 when unset)"
+    },
+    "type": {
+      "type": ["string", "null"],
+      "description": "Event type name (e.g. LOGIN, LOGOUT, REGISTER, CODE_TO_TOKEN, REFRESH_TOKEN, …)"
+    },
+    "realmId": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm ID"
+    },
+    "realmName": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm name"
+    },
+    "clientId": {
+      "type": ["string", "null"],
+      "description": "OAuth2/OIDC client ID that triggered the event"
+    },
+    "userId": {
+      "type": ["string", "null"],
+      "description": "Keycloak user ID (UUID)"
+    },
+    "sessionId": {
+      "type": ["string", "null"],
+      "description": "Keycloak session ID"
+    },
+    "ipAddress": {
+      "type": ["string", "null"],
+      "description": "IP address of the client"
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error code when the event represents a failure (null on success)"
+    },
+    "details": {
+      "type": ["object", "null"],
+      "description": "Arbitrary key-value pairs with extra context (e.g. username, redirect_uri, response_type)",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["id", "time", "type", "realmId", "realmName", "clientId", "userId", "sessionId", "ipAddress", "error", "details"]
+}
+```
+
+### Admin Event
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/FortuneN/kete/develop/schemas/json/admin_event.json",
+  "title": "AdminEvent",
+  "description": "Keycloak admin event as produced by the KETE JSON serializer (message header eventkind = ADMIN_EVENT; x-eventkind for HTTP and SOAP)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["string", "null"],
+      "description": "Unique event identifier (UUID)"
+    },
+    "time": {
+      "type": "integer",
+      "description": "Event timestamp in milliseconds since Unix epoch (0 when unset)"
+    },
+    "realmId": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm ID"
+    },
+    "realmName": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm name"
+    },
+    "authDetails": {
+      "description": "Details about the admin who performed the action",
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/AuthDetails" }
+      ]
+    },
+    "resourceType": {
+      "type": ["string", "null"],
+      "description": "Resource type name (e.g. USER, CLIENT, REALM, ROLE, GROUP, …); CUSTOM when Keycloak does not recognise the raw value — see resourceTypeAsString"
+    },
+    "resourceTypeAsString": {
+      "type": ["string", "null"],
+      "description": "Raw resource type string as recorded by Keycloak (same as resourceType unless resourceType is CUSTOM)"
+    },
+    "operationType": {
+      "type": ["string", "null"],
+      "description": "Operation performed (CREATE, UPDATE, DELETE, ACTION)"
+    },
+    "resourcePath": {
+      "type": ["string", "null"],
+      "description": "Path to the affected resource within the realm (e.g. users/uuid)"
+    },
+    "representation": {
+      "type": ["string", "null"],
+      "description": "JSON representation of the resource state after the operation (only when include-representation is enabled)"
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error code when the event represents a failure (null on success)"
+    },
+    "details": {
+      "type": ["object", "null"],
+      "description": "Arbitrary key-value pairs with extra context; only present when KETE runs on Keycloak 26.0 or later",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "resourceId": {
+      "type": ["string", "null"],
+      "description": "Segment after the last '/' of resourcePath; only present when KETE runs on Keycloak 26.4 or later"
+    }
+  },
+  "required": ["id", "time", "realmId", "realmName", "authDetails", "resourceType", "resourceTypeAsString", "operationType", "resourcePath", "representation", "error"],
+  "$defs": {
+    "AuthDetails": {
+      "title": "AuthDetails",
+      "description": "Identity of the admin who triggered the event",
+      "type": "object",
+      "properties": {
+        "realmId": {
+          "type": ["string", "null"],
+          "description": "Realm ID of the authenticating admin"
+        },
+        "realmName": {
+          "type": ["string", "null"],
+          "description": "Realm name of the authenticating admin"
+        },
+        "clientId": {
+          "type": ["string", "null"],
+          "description": "Client ID used by the admin (e.g. security-admin-console, admin-cli)"
+        },
+        "userId": {
+          "type": ["string", "null"],
+          "description": "Keycloak user ID of the admin (UUID)"
+        },
+        "ipAddress": {
+          "type": ["string", "null"],
+          "description": "IP address of the admin client"
+        }
+      },
+      "required": ["realmId", "realmName", "clientId", "userId", "ipAddress"]
+    }
+  }
+}
+```
+
+## Null Fields
+
+Every property is always present. Unset fields serialize as `null` (`time` is a primitive and serializes as `0` when unset), so consumers can distinguish "not set" from "empty string".
+
+## Keycloak Version Differences
+
+Messages are serialized straight from Keycloak's own `Event` and `AdminEvent` classes, so the exact set of properties depends on the Keycloak version KETE runs in:
+
+| Property | Message | Available since |
+|----------|---------|-----------------|
+| `details` | Admin Event | Keycloak 26.0 |
+| `resourceId` | Admin Event | Keycloak 26.4 |
+
+The schemas describe these as optional properties. Consumers should ignore properties they do not recognise so that future Keycloak versions do not break them.

--- a/schemas/json/admin_event.json
+++ b/schemas/json/admin_event.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/fortunen/kete/schemas/json/admin_event.json",
+  "$id": "https://raw.githubusercontent.com/FortuneN/kete/develop/schemas/json/admin_event.json",
   "title": "AdminEvent",
-  "description": "Keycloak admin event (eventkind header = ADMIN_EVENT)",
+  "description": "Keycloak admin event as produced by the KETE JSON serializer (message header eventkind = ADMIN_EVENT; x-eventkind for HTTP and SOAP)",
   "type": "object",
   "properties": {
     "id": {
@@ -10,8 +10,8 @@
       "description": "Unique event identifier (UUID)"
     },
     "time": {
-      "type": ["integer", "null"],
-      "description": "Event timestamp in milliseconds since Unix epoch"
+      "type": "integer",
+      "description": "Event timestamp in milliseconds since Unix epoch (0 when unset)"
     },
     "realmId": {
       "type": ["string", "null"],
@@ -30,7 +30,11 @@
     },
     "resourceType": {
       "type": ["string", "null"],
-      "description": "Type of resource affected (e.g. USER, CLIENT, REALM, ROLE, GROUP, …)"
+      "description": "Resource type name (e.g. USER, CLIENT, REALM, ROLE, GROUP, …); CUSTOM when Keycloak does not recognise the raw value — see resourceTypeAsString"
+    },
+    "resourceTypeAsString": {
+      "type": ["string", "null"],
+      "description": "Raw resource type string as recorded by Keycloak (same as resourceType unless resourceType is CUSTOM)"
     },
     "operationType": {
       "type": ["string", "null"],
@@ -47,8 +51,20 @@
     "error": {
       "type": ["string", "null"],
       "description": "Error code when the event represents a failure (null on success)"
+    },
+    "details": {
+      "type": ["object", "null"],
+      "description": "Arbitrary key-value pairs with extra context; only present when KETE runs on Keycloak 26.0 or later",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "resourceId": {
+      "type": ["string", "null"],
+      "description": "Segment after the last '/' of resourcePath; only present when KETE runs on Keycloak 26.4 or later"
     }
   },
+  "required": ["id", "time", "realmId", "realmName", "authDetails", "resourceType", "resourceTypeAsString", "operationType", "resourcePath", "representation", "error"],
   "$defs": {
     "AuthDetails": {
       "title": "AuthDetails",
@@ -65,7 +81,7 @@
         },
         "clientId": {
           "type": ["string", "null"],
-          "description": "Client ID used by the admin (e.g. security-admin-console)"
+          "description": "Client ID used by the admin (e.g. security-admin-console, admin-cli)"
         },
         "userId": {
           "type": ["string", "null"],
@@ -75,7 +91,8 @@
           "type": ["string", "null"],
           "description": "IP address of the admin client"
         }
-      }
+      },
+      "required": ["realmId", "realmName", "clientId", "userId", "ipAddress"]
     }
   }
 }

--- a/schemas/json/admin_event.json
+++ b/schemas/json/admin_event.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fortunen/kete/schemas/json/admin_event.json",
+  "title": "AdminEvent",
+  "description": "Keycloak admin event (eventkind header = ADMIN_EVENT)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["string", "null"],
+      "description": "Unique event identifier (UUID)"
+    },
+    "time": {
+      "type": ["integer", "null"],
+      "description": "Event timestamp in milliseconds since Unix epoch"
+    },
+    "realmId": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm ID"
+    },
+    "realmName": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm name"
+    },
+    "authDetails": {
+      "description": "Details about the admin who performed the action",
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/AuthDetails" }
+      ]
+    },
+    "resourceType": {
+      "type": ["string", "null"],
+      "description": "Type of resource affected (e.g. USER, CLIENT, REALM, ROLE, GROUP, …)"
+    },
+    "operationType": {
+      "type": ["string", "null"],
+      "description": "Operation performed (CREATE, UPDATE, DELETE, ACTION)"
+    },
+    "resourcePath": {
+      "type": ["string", "null"],
+      "description": "Path to the affected resource within the realm (e.g. users/uuid)"
+    },
+    "representation": {
+      "type": ["string", "null"],
+      "description": "JSON representation of the resource state after the operation (only when include-representation is enabled)"
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error code when the event represents a failure (null on success)"
+    }
+  },
+  "$defs": {
+    "AuthDetails": {
+      "title": "AuthDetails",
+      "description": "Identity of the admin who triggered the event",
+      "type": "object",
+      "properties": {
+        "realmId": {
+          "type": ["string", "null"],
+          "description": "Realm ID of the authenticating admin"
+        },
+        "realmName": {
+          "type": ["string", "null"],
+          "description": "Realm name of the authenticating admin"
+        },
+        "clientId": {
+          "type": ["string", "null"],
+          "description": "Client ID used by the admin (e.g. security-admin-console)"
+        },
+        "userId": {
+          "type": ["string", "null"],
+          "description": "Keycloak user ID of the admin (UUID)"
+        },
+        "ipAddress": {
+          "type": ["string", "null"],
+          "description": "IP address of the admin client"
+        }
+      }
+    }
+  }
+}

--- a/schemas/json/event.json
+++ b/schemas/json/event.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fortunen/kete/schemas/json/event.json",
+  "title": "Event",
+  "description": "Keycloak user/session event (eventkind header = EVENT)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["string", "null"],
+      "description": "Unique event identifier (UUID)"
+    },
+    "time": {
+      "type": ["integer", "null"],
+      "description": "Event timestamp in milliseconds since Unix epoch"
+    },
+    "type": {
+      "type": ["string", "null"],
+      "description": "Event type (e.g. LOGIN, LOGOUT, REGISTER, CODE_TO_TOKEN, REFRESH_TOKEN, …)"
+    },
+    "realmId": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm ID"
+    },
+    "realmName": {
+      "type": ["string", "null"],
+      "description": "Keycloak realm name"
+    },
+    "clientId": {
+      "type": ["string", "null"],
+      "description": "OAuth2/OIDC client ID that triggered the event"
+    },
+    "userId": {
+      "type": ["string", "null"],
+      "description": "Keycloak user ID (UUID)"
+    },
+    "sessionId": {
+      "type": ["string", "null"],
+      "description": "Keycloak session ID"
+    },
+    "ipAddress": {
+      "type": ["string", "null"],
+      "description": "IP address of the client"
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error code when the event represents a failure (null on success)"
+    },
+    "details": {
+      "type": ["object", "null"],
+      "description": "Arbitrary key-value pairs with extra context (e.g. redirect_uri, response_type)",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/json/event.json
+++ b/schemas/json/event.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/fortunen/kete/schemas/json/event.json",
+  "$id": "https://raw.githubusercontent.com/FortuneN/kete/develop/schemas/json/event.json",
   "title": "Event",
-  "description": "Keycloak user/session event (eventkind header = EVENT)",
+  "description": "Keycloak user event as produced by the KETE JSON serializer (message header eventkind = EVENT; x-eventkind for HTTP and SOAP)",
   "type": "object",
   "properties": {
     "id": {
@@ -10,12 +10,12 @@
       "description": "Unique event identifier (UUID)"
     },
     "time": {
-      "type": ["integer", "null"],
-      "description": "Event timestamp in milliseconds since Unix epoch"
+      "type": "integer",
+      "description": "Event timestamp in milliseconds since Unix epoch (0 when unset)"
     },
     "type": {
       "type": ["string", "null"],
-      "description": "Event type (e.g. LOGIN, LOGOUT, REGISTER, CODE_TO_TOKEN, REFRESH_TOKEN, …)"
+      "description": "Event type name (e.g. LOGIN, LOGOUT, REGISTER, CODE_TO_TOKEN, REFRESH_TOKEN, …)"
     },
     "realmId": {
       "type": ["string", "null"],
@@ -47,10 +47,11 @@
     },
     "details": {
       "type": ["object", "null"],
-      "description": "Arbitrary key-value pairs with extra context (e.g. redirect_uri, response_type)",
+      "description": "Arbitrary key-value pairs with extra context (e.g. username, redirect_uri, response_type)",
       "additionalProperties": {
         "type": "string"
       }
     }
-  }
+  },
+  "required": ["id", "time", "type", "realmId", "realmName", "clientId", "userId", "sessionId", "ipAddress", "error", "details"]
 }

--- a/src/test/java/io/github/fortunen/kete/unittests/serializers/jsonserializer/serializeTests.java
+++ b/src/test/java/io/github/fortunen/kete/unittests/serializers/jsonserializer/serializeTests.java
@@ -4,7 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.keycloak.events.Event;
@@ -14,6 +18,7 @@ import org.keycloak.events.admin.AuthDetails;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.fortunen.kete.serializers.JsonSerializer;
@@ -338,5 +343,188 @@ public class serializeTests {
 
 		assertThat(result).isNotNull();
 		assertThat(result.length > 50).isTrue();
+	}
+
+	// =====================================================================
+	// JSON Schema conformance (schemas/json)
+	// =====================================================================
+
+	@Test
+	public void shouldSerializeEventConformingToJsonSchema() throws Exception {
+
+		// arrange
+
+		var serializer = new JsonSerializer();
+		var schema = MAPPER.readTree(Files.readString(Path.of("schemas/json/event.json")));
+		var event = new Event();
+		event.setId("evt-001");
+		event.setTime(1700000000000L);
+		event.setType(EventType.LOGIN);
+		event.setRealmId("test-realm");
+		event.setRealmName("Test Realm");
+		event.setClientId("my-client");
+		event.setUserId("user-123");
+		event.setSessionId("sess-456");
+		event.setIpAddress("192.168.1.100");
+		event.setError("auth_failed");
+		event.setDetails(Map.of("username", "john.doe", "remember_me", "true"));
+
+		// act
+
+		var result = serializer.serialize(event);
+
+		// assert
+
+		var parsed = MAPPER.readTree(result);
+		assertThat(violationsOf(parsed, schema, schema)).isEmpty();
+	}
+
+	@Test
+	public void shouldSerializeEventWithNullFieldsConformingToJsonSchema() throws Exception {
+
+		// arrange
+
+		var serializer = new JsonSerializer();
+		var schema = MAPPER.readTree(Files.readString(Path.of("schemas/json/event.json")));
+		var event = new Event();
+
+		// act
+
+		var result = serializer.serialize(event);
+
+		// assert
+
+		var parsed = MAPPER.readTree(result);
+		assertThat(violationsOf(parsed, schema, schema)).isEmpty();
+	}
+
+	@Test
+	public void shouldSerializeAdminEventConformingToJsonSchema() throws Exception {
+
+		// arrange
+
+		var serializer = new JsonSerializer();
+		var schema = MAPPER.readTree(Files.readString(Path.of("schemas/json/admin_event.json")));
+		var authDetails = new AuthDetails();
+		authDetails.setRealmId("auth-realm");
+		authDetails.setRealmName("Auth Realm");
+		authDetails.setClientId("admin-cli");
+		authDetails.setUserId("admin-user");
+		authDetails.setIpAddress("10.0.0.1");
+		var adminEvent = new AdminEvent();
+		adminEvent.setId("adm-001");
+		adminEvent.setTime(1700000000000L);
+		adminEvent.setRealmId("test-realm");
+		adminEvent.setRealmName("Test Realm");
+		adminEvent.setAuthDetails(authDetails);
+		adminEvent.setResourceTypeAsString("USER");
+		adminEvent.setOperationType(OperationType.CREATE);
+		adminEvent.setResourcePath("users/user-123");
+		adminEvent.setRepresentation("{\"username\":\"newuser\"}");
+		adminEvent.setError("conflict");
+
+		// act
+
+		var result = serializer.serialize(adminEvent);
+
+		// assert
+
+		var parsed = MAPPER.readTree(result);
+		assertThat(violationsOf(parsed, schema, schema)).isEmpty();
+	}
+
+	@Test
+	public void shouldSerializeAdminEventWithNullFieldsConformingToJsonSchema() throws Exception {
+
+		// arrange
+
+		var serializer = new JsonSerializer();
+		var schema = MAPPER.readTree(Files.readString(Path.of("schemas/json/admin_event.json")));
+		var adminEvent = new AdminEvent();
+
+		// act
+
+		var result = serializer.serialize(adminEvent);
+
+		// assert
+
+		var parsed = MAPPER.readTree(result);
+		assertThat(violationsOf(parsed, schema, schema)).isEmpty();
+	}
+
+	private static List<String> violationsOf(JsonNode value, JsonNode schema, JsonNode root) {
+
+		var violations = new ArrayList<String>();
+
+		if (schema.has("$ref")) {
+			return violationsOf(value, root.at(schema.get("$ref").asText().substring(1)), root);
+		}
+
+		if (schema.has("oneOf")) {
+			var matchingBranches = 0;
+			for (var branch : schema.get("oneOf")) {
+				if (violationsOf(value, branch, root).isEmpty()) {
+					matchingBranches++;
+				}
+			}
+			if (matchingBranches != 1) {
+				violations.add(value + " matches " + matchingBranches + " oneOf branches, expected exactly 1");
+			}
+			return violations;
+		}
+
+		var allowedTypes = new ArrayList<String>();
+		if (schema.get("type").isArray()) {
+			schema.get("type").forEach(type -> allowedTypes.add(type.asText()));
+		} else {
+			allowedTypes.add(schema.get("type").asText());
+		}
+		if (!allowedTypes.contains(jsonTypeOf(value))) {
+			violations.add(value + " is " + jsonTypeOf(value) + ", expected one of " + allowedTypes);
+		}
+
+		if (value.isObject() && schema.has("properties")) {
+			for (var required : schema.get("required")) {
+				if (!value.has(required.asText())) {
+					violations.add("required property '" + required.asText() + "' is missing");
+				}
+			}
+			for (var property : value.properties()) {
+				if (!schema.get("properties").has(property.getKey())) {
+					violations.add("property '" + property.getKey() + "' is not described by the schema");
+				} else {
+					violations.addAll(violationsOf(property.getValue(), schema.get("properties").get(property.getKey()), root));
+				}
+			}
+		}
+
+		if (value.isObject() && schema.has("additionalProperties") && schema.get("additionalProperties").isObject()) {
+			value.forEach(entry -> violations.addAll(violationsOf(entry, schema.get("additionalProperties"), root)));
+		}
+
+		return violations;
+	}
+
+	private static String jsonTypeOf(JsonNode value) {
+
+		if (value.isNull()) {
+			return "null";
+		}
+		if (value.isTextual()) {
+			return "string";
+		}
+		if (value.isIntegralNumber()) {
+			return "integer";
+		}
+		if (value.isNumber()) {
+			return "number";
+		}
+		if (value.isBoolean()) {
+			return "boolean";
+		}
+		if (value.isArray()) {
+			return "array";
+		}
+		return "object";
 	}
 }


### PR DESCRIPTION
Adds JSON Schema (draft 2020-12) definitions for the two message shapes published to NATS, mirroring the existing Avro and Protobuf schemas under `schemas/`.

## New files

- `schemas/json/event.json` — user/session event (`eventkind: EVENT`)
- `schemas/json/admin_event.json` — admin event (`eventkind: ADMIN_EVENT`), including the nested `AuthDetails` object as a `$defs` reference

## Fields covered

### `event.json`
| Field | Type | Notes |
|---|---|---|
| `id` | string \| null | UUID |
| `time` | integer \| null | ms since epoch |
| `type` | string \| null | e.g. `LOGIN`, `LOGOUT` |
| `realmId` | string \| null | |
| `realmName` | string \| null | |
| `clientId` | string \| null | |
| `userId` | string \| null | UUID |
| `sessionId` | string \| null | |
| `ipAddress` | string \| null | |
| `error` | string \| null | null on success |
| `details` | object \| null | arbitrary string key-value map |

### `admin_event.json`
| Field | Type | Notes |
|---|---|---|
| `id` | string \| null | UUID |
| `time` | integer \| null | ms since epoch |
| `realmId` | string \| null | |
| `realmName` | string \| null | |
| `authDetails` | AuthDetails \| null | who performed the action |
| `resourceType` | string \| null | e.g. `USER`, `CLIENT` |
| `operationType` | string \| null | `CREATE`, `UPDATE`, `DELETE`, `ACTION` |
| `resourcePath` | string \| null | e.g. `users/uuid` |
| `representation` | string \| null | resource JSON (if include-representation enabled) |
| `error` | string \| null | null on success |

These schemas can be used to validate and parse messages received from NATS (e.g. with `ajv`, `jsonschema`, or any JSON Schema validator), discriminating between the two shapes using the `eventkind` NATS header.