### PR TITLE
Release: enforced pull-request flow documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,6 @@ Documentation must build strictly (`python -m mkdocs build --strict`) and the sh
 
 ## Pull requests
 
-- `develop` and `release` are protected: contributions arrive through pull requests with one approving review, and force-pushes to `release` are refused. Target `develop`; the `Build & Test` workflow (unit, integration and end-to-end suites, image build, strict docs build) runs on every pull request and must pass before the merge.
-- Keep the change focused; update the documentation page of every option or behaviour you touch.
-- Releases are cut by merging `develop` into `release` with a merge commit; the release workflow refuses to publish a tree that has not passed the Develop workflow.
+- `develop` and `release` are protected, for administrators too: nothing is pushed to them directly, force-pushes are refused, and a pull request into `develop` merges only once the `Build & Test` check (unit, integration and end-to-end suites, image build, strict docs build) has passed on its head commit.
+- Target `develop`. Keep the change focused; update the documentation page of every option or behaviour you touch.
+- Releases are cut with a pull request from `develop` into `release`, merged with a merge commit; the release workflow refuses to publish a tree that has not passed the Develop workflow.

--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -756,12 +756,14 @@ git push origin feature/my-new-feature
 
 ### Protected Branches
 
+`develop` and `release` accept changes only through pull requests; the rules apply to administrators as well.
+
 | Branch | Rules |
 |--------|-------|
-| `develop` | Contributions arrive through a pull request with one approving review; the `Build & Test` workflow runs on every pull request and must be green before the merge; repository administrators may push directly |
-| `release` | Pull request with one approving review for contributors, force-pushes refused; repository administrators merge `develop` into `release` directly; the release workflow's `Verify Develop Run` job refuses a tree that never passed the Develop workflow |
+| `develop` | Pull request required (no approval count — the project has one maintainer and GitHub does not let authors approve their own pull requests); the `Build & Test` check must pass on the head commit; force-pushes and deletion refused |
+| `release` | Pull request required, merged with a merge commit only; force-pushes refused; the release workflow's `Verify Develop Run` job refuses a tree that never passed the Develop workflow |
 
-To release, merge `develop` into `release` with a merge commit (`git merge --no-ff develop`) and push; the push to `release` starts the release workflow, which publishes the versioned images, the documentation, the tag and the GitHub release, and moves `:latest` last.
+To release, wait for the Develop workflow to pass on the `develop` head, open a pull request from `develop` into `release` and merge it (`gh pr merge --merge`); the resulting push to `release` starts the release workflow, which publishes the versioned images, the documentation, the tag and the GitHub release, and moves `:latest` last.
 
 ### Commit Message Format
 


### PR DESCRIPTION
Merges `develop` (890a040, Develop run 33019662651 green) into `release`: the CONTRIBUTING and developer-guide pages now describe the enforced pull-request flow for both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)